### PR TITLE
Add response/request DTOs for create booking

### DIFF
--- a/ChasRooms.Server/Domain/DTOs/BookingDto.cs
+++ b/ChasRooms.Server/Domain/DTOs/BookingDto.cs
@@ -1,4 +1,6 @@
-﻿namespace ChasRooms.Server.Domain.DTOs.Bookings
+﻿using ChasRooms.Server.Domain.Entities;
+
+namespace ChasRooms.Server.Domain.DTOs
 {
     public class BookingDto
     {
@@ -7,7 +9,7 @@
         public string Description { get; set; } = null!;
         public DateTime BookingStartTime { get; set; }
         public DateTime BookingEndTime { get; set; }
-        public int RoomId { get; set; }
-        public string RoomName { get; set; } = string.Empty;
+        public RoomDto Room { get; set; } = null!;
+        public List<UserDto> Users { get; set; } = null!;
     }
 }

--- a/ChasRooms.Server/Domain/DTOs/Bookings/BookingDto.cs
+++ b/ChasRooms.Server/Domain/DTOs/Bookings/BookingDto.cs
@@ -1,0 +1,13 @@
+﻿namespace ChasRooms.Server.Domain.DTOs.Bookings
+{
+    public class BookingDto
+    {
+        public Guid Id { get; set; }
+        public string Name { get; set; } = null!;
+        public string Description { get; set; } = null!;
+        public DateTime BookingStartTime { get; set; }
+        public DateTime BookingEndTime { get; set; }
+        public int RoomId { get; set; }
+        public string RoomName { get; set; } = string.Empty;
+    }
+}

--- a/ChasRooms.Server/Domain/DTOs/RoomDto.cs
+++ b/ChasRooms.Server/Domain/DTOs/RoomDto.cs
@@ -1,0 +1,12 @@
+﻿using ChasRooms.Server.Domain.Entities;
+
+namespace ChasRooms.Server.Domain.DTOs
+{
+    public class RoomDto
+    {
+        public int Id { get; set; }
+        public string RoomName { get; set; } = null!;
+        public int Capacity { get; set; }
+        public string Features { get; set; } = null!;
+    }
+}

--- a/ChasRooms.Server/Domain/DTOs/UserDto.cs
+++ b/ChasRooms.Server/Domain/DTOs/UserDto.cs
@@ -1,0 +1,11 @@
+﻿using ChasRooms.Server.Domain.Entities;
+
+namespace ChasRooms.Server.Domain.DTOs
+{
+    public class UserDto
+    {
+        public required string UserId { get; set; }
+        public string FirstName { get; set; } = null!;
+        public string LastName { get; set; } = null!;
+    }
+}

--- a/ChasRooms.Server/Domain/Entities/Booking.cs
+++ b/ChasRooms.Server/Domain/Entities/Booking.cs
@@ -10,8 +10,7 @@
 
 
         public int RoomId { get; set; }
-        public Room Room { get; set; } = null!;
-
+        public Room Room { get; set; } = null!; 
         public string OwnerId { get; set; } = null!;
         public User Owner { get; set; } = null!;
 

--- a/ChasRooms.Server/Features/Bookings/CreateBooking/CreateBooking.cs
+++ b/ChasRooms.Server/Features/Bookings/CreateBooking/CreateBooking.cs
@@ -118,8 +118,6 @@ namespace ChasRooms.Server.Features.Bookings.CreateBooking
                 BookingEndTime = cmd.EndTime
             };
 
-            
-
             db.Bookings.Add(booking);
 
             return new CreateBookingResponse

--- a/ChasRooms.Server/Features/Bookings/CreateBooking/CreateBooking.cs
+++ b/ChasRooms.Server/Features/Bookings/CreateBooking/CreateBooking.cs
@@ -1,0 +1,133 @@
+﻿using ChasRooms.Server.Domain.Entities;
+using ChasRooms.Server.Features.Bookings.CreateBooking.DTOs;
+using ChasRooms.Server.Infrastructure.Persistance;
+using FastEndpoints;
+using FastEndpoints.Security;
+using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Security.Claims;
+using Wolverine;
+using Wolverine.Attributes;
+using static Google.Apis.Requests.BatchRequest;
+
+namespace ChasRooms.Server.Features.Bookings.CreateBooking
+{
+    public record CreateBookingCommand(
+      int RoomId,
+      string UserId,
+      string Name,
+      string Description,
+      DateTime StartTime,
+      DateTime EndTime);
+
+    public class CreateBookingValidator : Validator<CreateBookingRequest>
+    {
+        public CreateBookingValidator()
+        {
+            RuleFor(x => x.RoomId)
+                .GreaterThan(0)
+                .WithMessage("Choose a valid room.");
+
+            RuleFor(x => x.Name)
+                .NotEmpty()
+                .WithMessage("Your booking needs to have a name.");
+
+            RuleFor(x => x.StartTime)
+                .GreaterThan(DateTime.Now)
+                .WithMessage("You cannot book the room in the past (no time traveling at Chas)!");
+
+            RuleFor(x => x.EndTime)
+                .GreaterThan(x => x.StartTime)
+                .WithMessage("The end time must be AFTER the start time");
+
+            RuleFor(x => x)
+                .Must(x => (x.EndTime - x.StartTime).TotalHours <= 3)
+                .WithMessage("A booking can be max 3 hours long.");
+        }
+    }
+    public class CreateBookingEndpoint : Endpoint<CreateBookingRequest, CreateBookingResponse>
+    {
+        private readonly IMessageBus _bus;
+
+        public CreateBookingEndpoint(IMessageBus bus)
+        {
+            _bus = bus;
+        }
+
+        public override void Configure()
+        {
+            Post("/bookings/createbooking");
+            Claims("UserId");
+        }
+
+        public override async Task HandleAsync(CreateBookingRequest req, CancellationToken ct)
+        {
+            var userId = User.FindFirstValue("UserId");
+
+            if (string.IsNullOrEmpty(userId))
+            {
+                ThrowError("Could not identify the user");
+            }
+
+            var command = new CreateBookingCommand(
+                req.RoomId,
+                userId,
+                req.Name,
+                req.Description,
+                req.StartTime,
+                req.EndTime
+            );
+
+            try
+            {
+            var response = await _bus.InvokeAsync<CreateBookingResponse>(command, ct);
+            await Send.OkAsync(response, ct);
+            }
+            catch (ApplicationException ex)
+            {
+                ThrowError(ex.Message);
+            }
+        }
+    }
+    public static class CreateBookingHandler
+    {
+        [Transactional]
+        public static async Task<CreateBookingResponse> Handle(CreateBookingCommand cmd, RoomDbContext db, CancellationToken ct)
+        {
+
+            var isOccupied = await db.Bookings.AnyAsync(b =>
+            b.RoomId == cmd.RoomId &&
+            cmd.StartTime < b.BookingEndTime &&
+            cmd.EndTime > b.BookingStartTime,
+            ct);
+
+            if (isOccupied)
+            {
+                throw new ApplicationException("Someone has already booked this room at this time, or within your requested time period.");
+            }
+
+            var booking = new Booking
+            {
+                Id = Guid.NewGuid(),
+                RoomId = cmd.RoomId,
+                OwnerId = cmd.UserId,
+                Name = cmd.Name,
+                Description = cmd.Description,
+                BookingStartTime = cmd.StartTime,
+                BookingEndTime = cmd.EndTime
+            };
+
+            
+
+            db.Bookings.Add(booking);
+
+            return new CreateBookingResponse
+            {
+                BookingId = booking.Id,
+                Message = "Booking successful!",
+                Success = true
+            };
+        }
+    }
+}

--- a/ChasRooms.Server/Features/Bookings/CreateBooking/DTOs/CreateBookingRequest.cs
+++ b/ChasRooms.Server/Features/Bookings/CreateBooking/DTOs/CreateBookingRequest.cs
@@ -3,8 +3,8 @@
     public record CreateBookingRequest
     {
         public int RoomId { get; set; }
-        public string Name { get; set; } = null!;
-        public string Description { get; set; } = null!;
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
         public DateTime StartTime { get; set; }
         public DateTime EndTime { get; set; }
     }

--- a/ChasRooms.Server/Features/Bookings/CreateBooking/DTOs/CreateBookingRequest.cs
+++ b/ChasRooms.Server/Features/Bookings/CreateBooking/DTOs/CreateBookingRequest.cs
@@ -1,0 +1,11 @@
+﻿namespace ChasRooms.Server.Features.Bookings.CreateBooking.DTOs
+{
+    public class CreateBookingRequest
+    {
+        public int RoomId { get; set; }
+        public string Name { get; set; } = null!;
+        public string Description { get; set; } = null!;
+        public DateTime StartTime { get; set; }
+        public DateTime EndTime { get; set; }
+    }
+}

--- a/ChasRooms.Server/Features/Bookings/CreateBooking/DTOs/CreateBookingRequest.cs
+++ b/ChasRooms.Server/Features/Bookings/CreateBooking/DTOs/CreateBookingRequest.cs
@@ -1,6 +1,6 @@
 ﻿namespace ChasRooms.Server.Features.Bookings.CreateBooking.DTOs
 {
-    public class CreateBookingRequest
+    public record CreateBookingRequest
     {
         public int RoomId { get; set; }
         public string Name { get; set; } = null!;

--- a/ChasRooms.Server/Features/Bookings/CreateBooking/DTOs/CreateBookingResponse.cs
+++ b/ChasRooms.Server/Features/Bookings/CreateBooking/DTOs/CreateBookingResponse.cs
@@ -1,8 +1,10 @@
 ﻿namespace ChasRooms.Server.Features.Bookings.CreateBooking.DTOs
 {
-    public class CreateBookingResponse
+    public record CreateBookingResponse
     {
         public Guid BookingId { get; set; }
         public bool Success { get; set; }
+
+        public string Message { get; set; } = null!;
     }
 }

--- a/ChasRooms.Server/Features/Bookings/CreateBooking/DTOs/CreateBookingResponse.cs
+++ b/ChasRooms.Server/Features/Bookings/CreateBooking/DTOs/CreateBookingResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace ChasRooms.Server.Features.Bookings.CreateBooking.DTOs
+{
+    public class CreateBookingResponse
+    {
+        public Guid BookingId { get; set; }
+        public bool Success { get; set; }
+    }
+}

--- a/ChasRooms.Server/Features/Bookings/ViewMyBookings/DTOs/ViewMyBookingsResponse.cs
+++ b/ChasRooms.Server/Features/Bookings/ViewMyBookings/DTOs/ViewMyBookingsResponse.cs
@@ -1,0 +1,10 @@
+﻿using ChasRooms.Server.Domain.DTOs.Bookings;
+using ChasRooms.Server.Domain.Entities;
+
+namespace ChasRooms.Server.Features.Bookings.ViewMyBookings.DTOs
+{
+    public class ViewMyBookingsResponse
+    {
+        public List<BookingDto> Bookings { get; set; } = new List<BookingDto>();
+    }
+}

--- a/ChasRooms.Server/Features/Bookings/ViewMyBookings/DTOs/ViewMyBookingsResponse.cs
+++ b/ChasRooms.Server/Features/Bookings/ViewMyBookings/DTOs/ViewMyBookingsResponse.cs
@@ -1,4 +1,4 @@
-﻿using ChasRooms.Server.Domain.DTOs.Bookings;
+﻿using ChasRooms.Server.Domain.DTOs;
 using ChasRooms.Server.Domain.Entities;
 
 namespace ChasRooms.Server.Features.Bookings.ViewMyBookings.DTOs

--- a/ChasRooms.Server/Features/Bookings/ViewMyBookings/ViewMyBookings.cs
+++ b/ChasRooms.Server/Features/Bookings/ViewMyBookings/ViewMyBookings.cs
@@ -1,4 +1,4 @@
-﻿using ChasRooms.Server.Domain.DTOs.Bookings;
+﻿using ChasRooms.Server.Domain.DTOs;
 using ChasRooms.Server.Domain.Entities;
 using ChasRooms.Server.Features.Bookings.ViewMyBookings.DTOs;
 using ChasRooms.Server.Infrastructure.Persistance;
@@ -63,12 +63,20 @@ namespace ChasRooms.Server.Features.Bookings.ViewMyBookings
                     Description = b.Description,
                     BookingStartTime = b.BookingStartTime,
                     BookingEndTime = b.BookingEndTime,
-
-                    RoomId = b.RoomId,
-
-                    RoomName = b.Room.RoomName
-                })
-                .ToListAsync(ct);
+                    Room = new RoomDto
+                    {
+                        Id = b.Room.Id,
+                        Capacity = b.Room.Capacity,
+                        Features = b.Room.Features,
+                        RoomName = b.Room.RoomName
+                    },
+                    Users = b.UserBookings.Select(ub => new UserDto
+                    {
+                        UserId = ub.User.Id,
+                        FirstName = ub.User.FirstName,
+                        LastName = ub.User.LastName,
+                    }).ToList(),
+                }).ToListAsync(ct);
         }
     }
 }

--- a/ChasRooms.Server/Features/Bookings/ViewMyBookings/ViewMyBookings.cs
+++ b/ChasRooms.Server/Features/Bookings/ViewMyBookings/ViewMyBookings.cs
@@ -1,0 +1,74 @@
+﻿using ChasRooms.Server.Domain.DTOs.Bookings;
+using ChasRooms.Server.Domain.Entities;
+using ChasRooms.Server.Features.Bookings.ViewMyBookings.DTOs;
+using ChasRooms.Server.Infrastructure.Persistance;
+using FastEndpoints;
+using Humanizer;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Security.Claims;
+using Wolverine;
+using YamlDotNet.Core.Events;
+using static System.Runtime.InteropServices.JavaScript.JSType;
+
+namespace ChasRooms.Server.Features.Bookings.ViewMyBookings
+{
+    public record ViewMyBookingsCommand(string UserId);
+
+    public class ViewMyBookingsEndpoint : EndpointWithoutRequest<ViewMyBookingsResponse>
+    {
+        private readonly IMessageBus _bus;
+
+        public ViewMyBookingsEndpoint(IMessageBus bus)
+        {
+            _bus = bus;
+        }
+
+        public override void Configure()
+        {
+            Get("/bookings/my");
+            Claims("UserId");
+        }
+
+        public override async Task HandleAsync(CancellationToken ct)
+        {
+            var user = User.FindFirstValue("UserId");
+
+            if (string.IsNullOrEmpty(user))
+            {
+                ThrowError("The userId is invalid.");
+            }
+
+            var command = new ViewMyBookingsCommand(user);
+
+            var bookings = await _bus.InvokeAsync<List<BookingDto>>(command, ct);
+
+            await Send.OkAsync(new ViewMyBookingsResponse
+            {
+                Bookings = bookings
+            }, ct);
+        }
+    }
+    public static class ViewMyBookingsHandler
+    {
+        public static async Task<List<BookingDto>> Handle(ViewMyBookingsCommand cmd, RoomDbContext db, CancellationToken ct)
+        {
+            return await db.Bookings
+                .Where(b => b.OwnerId == cmd.UserId)
+                .OrderBy(b => b.BookingStartTime)
+                .Select(b => new BookingDto
+                {
+                    Id = b.Id,
+                    Name = b.Name,
+                    Description = b.Description,
+                    BookingStartTime = b.BookingStartTime,
+                    BookingEndTime = b.BookingEndTime,
+
+                    RoomId = b.RoomId,
+
+                    RoomName = b.Room.RoomName
+                })
+                .ToListAsync(ct);
+        }
+    }
+}

--- a/ChasRooms.Server/Program.cs
+++ b/ChasRooms.Server/Program.cs
@@ -2,6 +2,8 @@ using ChasRooms.Server.Domain.Entities;
 using ChasRooms.Server.Infrastructure.Persistance;
 using FastEndpoints;
 using FastEndpoints.Swagger;
+using FastEndpoints.Security;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using System;
@@ -54,6 +56,25 @@ builder.Services.AddIdentity<User, IdentityRole>()
     .AddEntityFrameworkStores<RoomDbContext>()
     .AddDefaultTokenProviders();
 
+builder.Services.AddAuthentication(options =>
+{
+    options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+});
+
+builder.Services.AddAuthenticationJwtBearer(s => s.SigningKey = builder.Configuration["Jwt:Key"]!);
+
+builder.Services.ConfigureApplicationCookie(options =>
+{
+    options.Events.OnRedirectToLogin = context =>
+    {
+        context.Response.StatusCode = 401;
+        return Task.CompletedTask;
+    };
+});
+
+builder.Services.AddAuthorization();
+
 // Cors fix to allow localhost
 builder.Services.AddCors(options =>
 {
@@ -76,6 +97,9 @@ if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();
 }
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.UseOutputCache();
 

--- a/ChasRooms.Server/appsettings.Development.json
+++ b/ChasRooms.Server/appsettings.Development.json
@@ -1,0 +1,12 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=57302;Database=chasrooms-db;Username=postgres;Password=postgres"
+  }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -69,7 +69,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -279,7 +278,6 @@
       "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/parser": "^7.27.2",
@@ -1978,7 +1976,6 @@
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1989,7 +1986,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2050,7 +2046,6 @@
       "integrity": "sha512-PC0PDZfJg8sP7cmKe6L3QIL8GZwU5aRvUFedqSIpw3B+QjRSUZeeITC2M5XKeMXEzL6wccN196iy3JLwKNvDVA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.1",
         "@typescript-eslint/types": "8.48.1",
@@ -2302,7 +2297,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2445,7 +2439,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2817,7 +2810,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4053,7 +4045,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4115,7 +4106,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -4226,7 +4216,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4236,7 +4225,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4525,7 +4513,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4620,7 +4607,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.2.6.tgz",
       "integrity": "sha512-tI2l/nFHC5rLh7+5+o7QjKjSR04ivXDF4jcgV0f/bTQ+OJiITy5S6gaynVsEM+7RqzufMnVbIon6Sr5x1SDYaQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",


### PR DESCRIPTION
# Implement Room Booking Feature

This PR adds the ability to create room bookings with the following components:

- Created a new `CreateBooking` endpoint that handles POST requests to `/bookings/createbooking`
- Implemented validation rules for bookings:
  - Room ID must be valid
  - Booking must have a name
  - Start time must be in the future
  - End time must be after start time
  - Maximum booking duration is 3 hours
- Added conflict detection to prevent double-booking rooms
- Created request/response DTOs for the booking process
- Added development connection string configuration

The endpoint authenticates users via claims and uses Wolverine for message handling with transactional support.